### PR TITLE
update deprecated boost url

### DIFF
--- a/com.obsproject.Studio.Plugin.RewardsTheater.yaml
+++ b/com.obsproject.Studio.Plugin.RewardsTheater.yaml
@@ -23,7 +23,7 @@ modules:
       - '*'
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.87.0/source/boost_1_87_0.tar.bz2
+        url: https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.bz2
         sha256: af57be25cb4c4f4b413ed692fe378affb4352ea50fbe294a11ef548f4d527d89
 
   - name: fmt


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
